### PR TITLE
Feature/nag 34 implement global component styling

### DIFF
--- a/src/app/test/page.js
+++ b/src/app/test/page.js
@@ -7,6 +7,7 @@ import ProductCard from "@/components/ProductCard";
 import HeroSlider from "@/components/HeroSlider";
 import GlobalAccordion from "@/components/GlobalAccordion";
 import NutritionTable from "@/components/NutritionTable";
+import { Button } from "@/components/ui/button";
 
 const products = [
     {
@@ -138,6 +139,21 @@ export default function TestPage() {
         <HeroSlider slides={slides} />
         <main className="p-10">
             <h1 className="text-3xl font-bold">Component Preview</h1>
+            <section className="my-10">
+              <h2 className="text-2xl font-semibold mb-4">Button Variants</h2>
+              <div className="flex flex-wrap gap-4">
+                <Button variant="default">Default</Button>
+                <Button variant="ghost">Ghost</Button>
+                <Button variant="outline">Outline</Button>
+                <Button variant="destructive">Destructive</Button>
+                <Button variant="green">Green</Button>
+                <Button variant="greenOutlined">Green Outlined</Button>
+                <Button variant="yellow">Yellow</Button>
+                <Button variant="pink">Pink</Button>
+                <Button variant="pinkOutlined">Pink Outlined</Button>
+                <Button variant="grey">Grey</Button>
+              </div>
+            </section>
             <ProductCarousel products={products} />
             <br></br>
             <br></br>

--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -28,10 +28,9 @@ export default function Banner() {
     return (
         <div className="bg-[var(--color-pink)] text-black text-sm py-0 px-4 flex items-center justify-between relative">
             {/* Left Arrow Button to navigate to previous message */}
-            <Button variant="ghost" size="icon" onClick={prevMessage} className="text-black hover:text-gray-100 hover:bg-transparent">
-                <ArrowLeft size={20} />
-            </Button>
-
+            <button  className="outline-arrow" onClick={prevMessage}>
+                <ArrowLeft size={20} /> 
+            </button>
             {/* Banner Content: message text, optional link and emoji */}
             <p className="flex-1 text-center whitespace-nowrap overflow-hidden text-ellipsis">
                 <strong>{messages[currentIndex].text}</strong>{" "}
@@ -47,9 +46,9 @@ export default function Banner() {
             </p>
 
             {/* Right Arrow Button to navigate to next message */}
-            <Button variant="ghost" size="icon" onClick={nextMessage} className="text-black hover:text-gray-100 hover:bg-transparent">
-                <ArrowRight size={20} />
-            </Button>
+            <button  className="outline-arrow" onClick={nextMessage}>
+                <ArrowRight size={20} /> 
+            </button>
         </div>
     );
 }

--- a/src/components/Banner.jsx
+++ b/src/components/Banner.jsx
@@ -28,9 +28,9 @@ export default function Banner() {
     return (
         <div className="bg-[var(--color-pink)] text-black text-sm py-0 px-4 flex items-center justify-between relative">
             {/* Left Arrow Button to navigate to previous message */}
-            <button  className="outline-arrow" onClick={prevMessage}>
+            <Button  variant="arrow" onClick={prevMessage}>
                 <ArrowLeft size={20} /> 
-            </button>
+            </Button>
             {/* Banner Content: message text, optional link and emoji */}
             <p className="flex-1 text-center whitespace-nowrap overflow-hidden text-ellipsis">
                 <strong>{messages[currentIndex].text}</strong>{" "}
@@ -46,9 +46,9 @@ export default function Banner() {
             </p>
 
             {/* Right Arrow Button to navigate to next message */}
-            <button  className="outline-arrow" onClick={nextMessage}>
+            <Button  variant="arrow" onClick={nextMessage}>
                 <ArrowRight size={20} /> 
-            </button>
+            </Button>
         </div>
     );
 }

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -47,35 +47,24 @@ export default function Footer() {
                         <div className="flex items-center gap-x-4">
                             {/* Instagram */}
                             {/* Link to the Instagram profile */}
-                            <Button variant="ghost" size="icon" className="w-12 h-12 flex justify-center items-center" asChild>
-                                <Link href="https://instagram.com/nutrinanaa" target="_blank">
-                                    <Image src={instagramLogo} alt="Instagram" width={24} height={24} />
-                                </Link>
-                            </Button>
-
+                            <Link href="https://instagram.com/nutrinanaa" target="_blank" className="social-button">
+                                <Image src={instagramLogo} alt="Instagram" width={24} height={24} />
+                            </Link>
                             {/* TikTok */}
                             {/* Link to the TikTok profile */}
-                            <Button variant="ghost" size="icon" className="w-12 h-12 flex justify-center items-center" asChild>
-                                <Link href="https://tiktok.com/" target="_blank">
-                                    <Image src={tiktokLogo} alt="TikTok" width={24} height={24} />
-                                </Link>
-                            </Button>
-
+                            <Link href="https://tiktok.com/" target="_blank" className="social-button">
+                                <Image src={tiktokLogo} alt="TikTok" width={24} height={24} />
+                            </Link>
                             {/* DELLI */}
                             {/* Link to the Delli marketplace */}
-                            <Button variant="ghost" className="w-20 h-12 flex justify-center items-center" asChild>
-                                <Link href="https://delli.market/collections/nutrinana">
-                                    <Image src={delliLogo} alt="Delli" width={70} height={35} />
-                                </Link>
-                            </Button>
-
+                            <Link href="https://delli.market/collections/nutrinana" target="_blank" className="social-button">
+                                <Image src={delliLogo} alt="Delli" width={50} height={25} />
+                            </Link>
                             {/* The Black Farmer */}
                             {/* Link to The Black Farmer website */}
-                            <Button variant="ghost" className="w-30 h-12 flex justify-center items-center" asChild>
-                                <Link href="https://theblackfarmer.com/">
-                                    <Image src={blackFarmerLogo} alt="The Black Farmer" width={180} height={90} />
-                                </Link>
-                            </Button>
+                            <Link href="https://theblackfarmer.com/" target="_blank" className="social-button">
+                                <Image src={blackFarmerLogo} alt="The Black Farmer" width={100} height={50} />
+                            </Link>
                         </div>
                     </div>
                 </div>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -47,22 +47,22 @@ export default function Footer() {
                         <div className="flex items-center gap-x-4">
                             {/* Instagram */}
                             {/* Link to the Instagram profile */}
-                            <Link href="https://instagram.com/nutrinanaa" target="_blank" className="social-button">
+                            <Link href="https://instagram.com/nutrinanaa" target="_blank" className="social-icon">
                                 <Image src={instagramLogo} alt="Instagram" width={24} height={24} />
                             </Link>
                             {/* TikTok */}
                             {/* Link to the TikTok profile */}
-                            <Link href="https://tiktok.com/" target="_blank" className="social-button">
+                            <Link href="https://tiktok.com/" target="_blank" className="social-icon">
                                 <Image src={tiktokLogo} alt="TikTok" width={24} height={24} />
                             </Link>
                             {/* DELLI */}
                             {/* Link to the Delli marketplace */}
-                            <Link href="https://delli.market/collections/nutrinana" target="_blank" className="social-button">
+                            <Link href="https://delli.market/collections/nutrinana" target="_blank" className="social-icon">
                                 <Image src={delliLogo} alt="Delli" width={50} height={25} />
                             </Link>
                             {/* The Black Farmer */}
                             {/* Link to The Black Farmer website */}
-                            <Link href="https://theblackfarmer.com/" target="_blank" className="social-button">
+                            <Link href="https://theblackfarmer.com/" target="_blank" className="social-icon">
                                 <Image src={blackFarmerLogo} alt="The Black Farmer" width={100} height={50} />
                             </Link>
                         </div>

--- a/src/components/HeroSlider.jsx
+++ b/src/components/HeroSlider.jsx
@@ -52,11 +52,13 @@ export default function HeroSlider({ slides = [] }) {
                         <p className="text-lg md:text-2xl mb-6 max-w-xl">
                             {slide.subtitle}
                         </p>
-                        <Link href={slide.buttonLink || "#"} passHref>
-                            <Button variant="green"size="smaller">
-                                {slide.buttonText}
-                            </Button>
-                        </Link>
+                        <Button
+                            variant="green"
+                            size="smaller"
+                            onClick={() => window.location.href = slide.buttonLink || "#"}
+                        >
+                            {slide.buttonText}
+                        </Button>
                         
                     </div>
                 </div>

--- a/src/components/HeroSlider.jsx
+++ b/src/components/HeroSlider.jsx
@@ -53,10 +53,11 @@ export default function HeroSlider({ slides = [] }) {
                             {slide.subtitle}
                         </p>
                         <Link href={slide.buttonLink || "#"} passHref>
-                            <button className="white-bg-button">
-                                        {slide.buttonText}
-                            </button>
+                            <Button variant="green"size="smaller">
+                                {slide.buttonText}
+                            </Button>
                         </Link>
+                        
                     </div>
                 </div>
             ))}

--- a/src/components/HeroSlider.jsx
+++ b/src/components/HeroSlider.jsx
@@ -53,9 +53,9 @@ export default function HeroSlider({ slides = [] }) {
                             {slide.subtitle}
                         </p>
                         <Link href={slide.buttonLink || "#"} passHref>
-                            <Button size="lg" className="bg-white text-black hover:bg-white/90">
-                                {slide.buttonText}
-                            </Button>
+                            <button className="white-bg-button">
+                                        {slide.buttonText}
+                            </button>
                         </Link>
                     </div>
                 </div>

--- a/src/components/HeroSlider.jsx
+++ b/src/components/HeroSlider.jsx
@@ -64,7 +64,7 @@ export default function HeroSlider({ slides = [] }) {
             {/* Pagination Dots for manual navigation */}
             <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-30 flex space-x-2">
                 {slides.map((_, index) => (
-                    <button
+                    <Button variant="outline" size="icon"
                     key={index}
                     onClick={() => goToSlide(index)}
                     className={`w-3 h-3 rounded-full ${

--- a/src/components/HeroSlider.jsx
+++ b/src/components/HeroSlider.jsx
@@ -64,7 +64,7 @@ export default function HeroSlider({ slides = [] }) {
             {/* Pagination Dots for manual navigation */}
             <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-30 flex space-x-2">
                 {slides.map((_, index) => (
-                    <Button variant="outline" size="icon"
+                    <Button size="icon"
                     key={index}
                     onClick={() => goToSlide(index)}
                     className={`w-3 h-3 rounded-full ${

--- a/src/components/HeroSlider.jsx
+++ b/src/components/HeroSlider.jsx
@@ -66,7 +66,7 @@ export default function HeroSlider({ slides = [] }) {
             {/* Pagination Dots for manual navigation */}
             <div className="absolute bottom-4 left-1/2 transform -translate-x-1/2 z-30 flex space-x-2">
                 {slides.map((_, index) => (
-                    <Button size="icon"
+                    <Button variant="noOutline" size="icon"
                     key={index}
                     onClick={() => goToSlide(index)}
                     className={`w-3 h-3 rounded-full ${

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -114,29 +114,26 @@ export default function Navbar() {
 
                 {/* Social media buttons in mobile menu */}
                 <div className="flex justify-start space-x-4 px-6 pb-6 w-full">
-                    <Button variant="ghost" size="icon" className="w-12 h-12" asChild>
-                        <Link href="https://instagram.com/nutrinanaa" target="_blank">
-                            <img src="/icons/instagram-logo.svg" alt="Instagram" className="h-6" />
-                        </Link>
-                    </Button>
-
-                    <Button variant="ghost" size="icon" className="w-12 h-12" asChild>
-                        <Link href="https://tiktok.com/" target="_blank">
-                            <img src="/icons/tiktok-logo.svg" alt="TikTok" className="h-6" />
-                        </Link>
-                    </Button>
-
-                    <Button variant="ghost" className="w-20 h-12 flex justify-center items-center" asChild>
-                        <Link href="https://delli.market/collections/nutrinana">
-                            <img src="/icons/delli-logo.svg" alt="Delli" className="h-6" />
-                        </Link>
-                    </Button>
-
-                    <Button variant="ghost" className="w-30 h-12 flex justify-center items-center" asChild>
-                        <Link href="https://theblackfarmer.com/">
-                            <img src="/icons/black-farmer-logo.svg" alt="Black Farmer" className="h-6" />
-                        </Link>
-                    </Button>
+                    {/* Instagram */}
+                    {/* Link to the Instagram profile */}
+                    <Link href="https://instagram.com/nutrinanaa" target="_blank" className="social-button">
+                        <img src="/icons/instagram-logo.svg" alt="Instagram" width={24} height={24} />
+                    </Link>
+                    {/* TikTok */}
+                    {/* Link to the TikTok profile */}
+                    <Link href="https://tiktok.com/" target="_blank" className="social-button">
+                        <img src="/icons/tiktok-logo.svg" alt="TikTok" width={24} height={24} />
+                    </Link>
+                    {/* DELLI */}
+                    {/* Link to the Delli marketplace */}
+                    <Link href="https://delli.market/collections/nutrinana" target="_blank" className="social-button">
+                        <img src="/icons/delli-logo.svg" alt="Delli" width={50} height={25} />
+                    </Link>
+                    {/* The Black Farmer */}
+                    {/* Link to The Black Farmer website */}
+                    <Link href="https://theblackfarmer.com/" target="_blank" className="social-button">
+                        <img src="/icons/black-farmer-logo.svg" alt="The Black Farmer" width={100} height={50} />
+                    </Link>
                 </div>
             </div>
         </nav>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -46,10 +46,9 @@ export default function Navbar() {
 
                 {/* Mobile layout: Hamburger left, logo center */}
                 <div className="flex items-center md:hidden w-full justify-between">
-                    <Button variant="ghost" size="icon" onClick={() => setIsOpen(!isOpen)} className="relative z-50 ml-4">
+                    <button className="side-panel-button" onClick={() => setIsOpen(!isOpen)}>
                         {isOpen ? <X size={24} /> : <Menu size={24} />}
-                    </Button>
-
+                    </button>
                     <Link href="/" className="absolute left-1/2 transform -translate-x-1/2">
                         <img src="/NUTRINA_LOGO.png" alt="Nutrinana Logo" className="h-12 mb-2" />
                     </Link>
@@ -84,9 +83,9 @@ export default function Navbar() {
                 
                 {/* Close button and logo in mobile menu */}
                 <div className="flex items-center px-4 py-4">
-                    <Button variant="ghost" size="icon" onClick={() => setIsOpen(false)} className="absolute left-8 mt-11">
+                    <button className="side-panel-button absolute left-8 mt-11" onClick={() => setIsOpen(false)}>
                         <X size={24} />
-                    </Button>
+                    </button>
                     <Link href="/" onClick={() => setIsOpen(false)} className="mx-auto">
                         <img src="/NUTRINA_LOGO.png" alt="Nutrinana Logo" className="h-12 mt-6" />
                     </Link>

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -46,9 +46,9 @@ export default function Navbar() {
 
                 {/* Mobile layout: Hamburger left, logo center */}
                 <div className="flex items-center md:hidden w-full justify-between">
-                    <button className="side-panel-button" onClick={() => setIsOpen(!isOpen)}>
+                    <Button variant="outline" onClick={() => setIsOpen(!isOpen)}>
                         {isOpen ? <X size={24} /> : <Menu size={24} />}
-                    </button>
+                    </Button>
                     <Link href="/" className="absolute left-1/2 transform -translate-x-1/2">
                         <img src="/NUTRINA_LOGO.png" alt="Nutrinana Logo" className="h-12 mb-2" />
                     </Link>
@@ -82,10 +82,10 @@ export default function Navbar() {
             <div className={`fixed inset-0 bg-white z-50 w-full h-screen flex flex-col border-r border-gray-300 transform transition-transform duration-300 ${isOpen ? "translate-x-0" : "-translate-x-full"}`}>
                 
                 {/* Close button and logo in mobile menu */}
-                <div className="flex items-center px-4 py-4">
-                    <button className="side-panel-button absolute left-8 mt-11" onClick={() => setIsOpen(false)}>
+                <div className="flex items-center px-4 py-4 ">
+                    <Button variant="outline" className=" absolute left-5 mt-11" onClick={() => setIsOpen(false)}>
                         <X size={24} />
-                    </button>
+                    </Button>
                     <Link href="/" onClick={() => setIsOpen(false)} className="mx-auto">
                         <img src="/NUTRINA_LOGO.png" alt="Nutrinana Logo" className="h-12 mt-6" />
                     </Link>
@@ -116,22 +116,22 @@ export default function Navbar() {
                 <div className="flex justify-start space-x-4 px-6 pb-6 w-full">
                     {/* Instagram */}
                     {/* Link to the Instagram profile */}
-                    <Link href="https://instagram.com/nutrinanaa" target="_blank" className="social-button">
+                    <Link href="https://instagram.com/nutrinanaa" target="_blank" className="social-icon">
                         <img src="/icons/instagram-logo.svg" alt="Instagram" width={24} height={24} />
                     </Link>
                     {/* TikTok */}
                     {/* Link to the TikTok profile */}
-                    <Link href="https://tiktok.com/" target="_blank" className="social-button">
+                    <Link href="https://tiktok.com/" target="_blank" className="social-icon">
                         <img src="/icons/tiktok-logo.svg" alt="TikTok" width={24} height={24} />
                     </Link>
                     {/* DELLI */}
                     {/* Link to the Delli marketplace */}
-                    <Link href="https://delli.market/collections/nutrinana" target="_blank" className="social-button">
+                    <Link href="https://delli.market/collections/nutrinana" target="_blank" className="social-icon">
                         <img src="/icons/delli-logo.svg" alt="Delli" width={50} height={25} />
                     </Link>
                     {/* The Black Farmer */}
                     {/* Link to The Black Farmer website */}
-                    <Link href="https://theblackfarmer.com/" target="_blank" className="social-button">
+                    <Link href="https://theblackfarmer.com/" target="_blank" className="social-icon">
                         <img src="/icons/black-farmer-logo.svg" alt="The Black Farmer" width={100} height={50} />
                     </Link>
                 </div>

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -115,7 +115,7 @@ export default function ProductCard({
                         {/* Price and Rating */}
                         <div className="mt-6 flex items-center justify-between pb-3">
                             <span className="text-6xl font-bold text-gray-800">{price}</span>
-                            {rating && <span className="text-yellow-500 text-lg">⭐ {rating}</span>}
+                            {rating && <span className="rating">⭐ {rating}</span>}
                         </div>
 
                         {/* Shop buttons */}

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -121,10 +121,8 @@ export default function ProductCard({
                         {/* Shop buttons */}
                         <div className="w-full flex flex-col sm:flex-row gap-4 mt-auto pt-4">
                             {shopLinks.map(({ text, href }, index) => (
-                                <Link key={index} href={href} className="w-full sm:w-1/2">
-                                    <button className="white-bg-button">
-                                        {text}
-                                    </button>
+                                <Link key={index} href={href} className="white-bg-link w-full sm:w-1/2">
+                                    {text}
                                 </Link>
                             ))}
                         </div>

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -133,7 +133,7 @@ export default function ProductCard({
                                 {shopLinks[0]?.text}
                             </Button>
                             <Button
-                                variant="green"
+                                variant="greenOutlined"
                                 size="default"
                                 className="w-full sm:w-1/2"
                                 onClick={(event) => {
@@ -143,7 +143,7 @@ export default function ProductCard({
                             >
                                 {shopLinks[1]?.text}
                             </Button>
-</div>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { CircleCheck } from "lucide-react";
 import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
 import "@/styles/globals.css"; // Ensure global styles are imported
 
 /**
@@ -120,12 +121,29 @@ export default function ProductCard({
 
                         {/* Shop buttons */}
                         <div className="w-full flex flex-col sm:flex-row gap-4 mt-auto pt-4">
-                            {shopLinks.map(({ text, href }, index) => (
-                                <Link key={index} href={href} className="white-bg-link w-full sm:w-1/2">
-                                    {text}
-                                </Link>
-                            ))}
-                        </div>
+                            <Button
+                                variant="yellow"
+                                size="default"
+                                className="w-full sm:w-1/2"
+                                onClick={(event) => {
+                                    event.stopPropagation(); //prevents the card's onClick from firing
+                                    window.location.href = shopLinks[0]?.href;
+                                }}
+                            >
+                                {shopLinks[0]?.text}
+                            </Button>
+                            <Button
+                                variant="green"
+                                size="default"
+                                className="w-full sm:w-1/2"
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    window.location.href = shopLinks[1]?.href;
+                                }}
+                            >
+                                {shopLinks[1]?.text}
+                            </Button>
+</div>
                     </div>
                 </div>
             </div>

--- a/src/components/ProductCard.jsx
+++ b/src/components/ProductCard.jsx
@@ -2,9 +2,9 @@
 
 import Image from "next/image";
 import Link from "next/link";
-import { Button } from "@/components/ui/button";
 import { CircleCheck } from "lucide-react";
 import { useRouter } from "next/navigation";
+import "@/styles/globals.css"; // Ensure global styles are imported
 
 /**
  * ProductCard component for displaying product information.
@@ -122,9 +122,9 @@ export default function ProductCard({
                         <div className="w-full flex flex-col sm:flex-row gap-4 mt-auto pt-4">
                             {shopLinks.map(({ text, href }, index) => (
                                 <Link key={index} href={href} className="w-full sm:w-1/2">
-                                    <Button variant="outline" className="w-full text-sm md:text-base truncate">
+                                    <button className="white-bg-button">
                                         {text}
-                                    </Button>
+                                    </button>
                                 </Link>
                             ))}
                         </div>

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -11,20 +11,32 @@ const buttonVariants = cva(
       variant: {
         default:
           "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        green:
+          "border bg-[var(--color-green)] text-primary-foreground shadow-xs hover:bg-[var(--color-green)]/80",
+        yellow:
+          "border border-primary bg-[var(--color-light-yellow)] text-primary shadow-xs hover:bg-[var(--color-light-yellow)]/80",
+        pink:
+          "border bg-[var(--color-pink)] text-primary-foreground shadow-xs hover:bg-[var(--color-pink)]/80",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
         outline:
-          "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
+          "border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+        ghost: 
+          "hover:bg-accent hover:text-accent-foreground",
+        link: 
+          "text-primary underline-offset-4 hover:underline",
+        arrow:
+          "w-4 h-8 p-0 text-base font-medium bg-transparent text-[var(--color-raisin)] hover:text-white transition-colors",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
         icon: "size-9",
+        smaller: "w-30 h-10",
+        larger: "w-40 h-10", 
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -12,19 +12,19 @@ const buttonVariants = cva(
         default:
           "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
         green:
-          "border bg-[var(--color-green)] text-primary-foreground shadow-xs hover:bg-[var(--color-green)]/80",
-        greenOutlined: 
-          "border border-[var(--color-raisin)] bg-[var(--color-green)] text-primary-foreground shadow-xs hover:bg-[var(--color-green)]/80",
+          "border border-white bg-[var(--color-green)] text-primary-foreground shadow-xs transition-transform duration-250 ease-in-out hover:scale-110 hover:border-2",
+        greenOutlined:
+          "border border-[var(--color-raisin)] bg-[var(--color-green)] text-primary-foreground shadow-xs transition-transform duration-250 ease-in-out hover:scale-110 hover:border-2",
         yellow:
-          "border border-primary bg-[var(--color-light-yellow)] text-[var(--color-raisin)] shadow-xs hover:bg-[var(--color-light-yellow)]/70",
+          "border border-primary bg-[var(--color-light-yellow)] text-[var(--color-raisin)] shadow-xs transition-transform duration-250 ease-in-out hover:scale-110 hover:border-2",
         pink:
-          "border bg-[var(--color-pink)] text-primary-foreground shadow-xs hover:bg-[var(--color-pink)]/80",
-        pinkOutlined: 
-          "border border-[var(--color-raisin)] bg-[var(--color-pink)] text-primary-foreground shadow-xs hover:bg-[var(--color-pink)]/80",
+          "border border-white bg-[var(--color-pink)] text-primary-foreground shadow-xs transition-transform duration-250 ease-in-out hover:scale-110 hover:border-2",
+        pinkOutlined:
+          "border border-[var(--color-raisin)] bg-[var(--color-pink)] text-primary-foreground shadow-xs transition-transform duration-250 ease-in-out hover:scale-110 hover:border-2",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
-        grey: 
-          "border border-[var(--color-raisin)] bg-[var(--color-grey)] text-[var(--color-raisin)] shadow-xs hover:bg-[var(--color-grey)]/80",
+        grey:
+          "border border-[var(--color-raisin)] bg-[var(--color-grey)] text-[var(--color-raisin)] shadow-xs transition-transform duration-250 ease-in-out hover:scale-110 hover:border-2",
         outline:
           "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
           // "border-input bg-background hover:bg-accent hover:text-accent-foreground",

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -13,14 +13,21 @@ const buttonVariants = cva(
           "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
         green:
           "border bg-[var(--color-green)] text-primary-foreground shadow-xs hover:bg-[var(--color-green)]/80",
+        greenOutlined: 
+          "border border-[var(--color-raisin)] bg-[var(--color-green)] text-primary-foreground shadow-xs hover:bg-[var(--color-green)]/80",
         yellow:
-          "border border-primary bg-[var(--color-light-yellow)] text-primary shadow-xs hover:bg-[var(--color-light-yellow)]/70",
+          "border border-primary bg-[var(--color-light-yellow)] text-[var(--color-raisin)] shadow-xs hover:bg-[var(--color-light-yellow)]/70",
         pink:
           "border bg-[var(--color-pink)] text-primary-foreground shadow-xs hover:bg-[var(--color-pink)]/80",
+        pinkOutlined: 
+          "border border-[var(--color-raisin)] bg-[var(--color-pink)] text-primary-foreground shadow-xs hover:bg-[var(--color-pink)]/80",
         destructive:
           "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40",
+        grey: 
+          "border border-[var(--color-raisin)] bg-[var(--color-grey)] text-[var(--color-raisin)] shadow-xs hover:bg-[var(--color-grey)]/80",
         outline:
-          "border-input bg-background hover:bg-accent hover:text-accent-foreground",
+          "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
+          // "border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
         ghost: 

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -14,7 +14,7 @@ const buttonVariants = cva(
         green:
           "border bg-[var(--color-green)] text-primary-foreground shadow-xs hover:bg-[var(--color-green)]/80",
         yellow:
-          "border border-primary bg-[var(--color-light-yellow)] text-primary shadow-xs hover:bg-[var(--color-light-yellow)]/80",
+          "border border-primary bg-[var(--color-light-yellow)] text-primary shadow-xs hover:bg-[var(--color-light-yellow)]/70",
         pink:
           "border bg-[var(--color-pink)] text-primary-foreground shadow-xs hover:bg-[var(--color-pink)]/80",
         destructive:

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -27,7 +27,6 @@ const buttonVariants = cva(
           "border border-[var(--color-raisin)] bg-[var(--color-grey)] text-[var(--color-raisin)] shadow-xs transition-transform duration-250 ease-in-out hover:scale-110 hover:border-2",
         outline:
           "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
-          // "border-input bg-background hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
         ghost: 

--- a/src/components/ui/button.jsx
+++ b/src/components/ui/button.jsx
@@ -27,6 +27,8 @@ const buttonVariants = cva(
           "border border-[var(--color-raisin)] bg-[var(--color-grey)] text-[var(--color-raisin)] shadow-xs transition-transform duration-250 ease-in-out hover:scale-110 hover:border-2",
         outline:
           "border border-input bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
+        noOutline:
+          "bg-background shadow-xs hover:bg-accent hover:text-accent-foreground",
         secondary:
           "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
         ghost: 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -246,3 +246,86 @@ a {
       height: 0;
   }
 }
+
+/* White background button styles */
+.white-bg-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem; /* Adjust for text-sm */
+  font-weight: 500;
+  border: 1px solid var(--input-border-color, #d1d5db); /* Matches outline variant */
+  background-color: var(--background-color, #ffffff);
+  color: var(--text-color, #000000);
+  border-radius: 0.375rem; /* Matches rounded-md */
+  transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
+  cursor: pointer;
+  text-align: center;
+  white-space: nowrap;
+}
+.white-bg-button:hover {
+  background-color: var(--accent-color, #f3f4f6); /* Matches hover:bg-accent */
+  color: var(--accent-foreground-color, #000000); /* Matches hover:text-accent-foreground */
+}
+.white-bg-button:disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+
+/* Outline arrow button styles */
+.outline-arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem; /* Matches size="icon" */
+  height: 2rem;
+  padding: 0;
+  font-size: 1rem;
+  font-weight: 500;
+  background-color: transparent;
+  color: var(--text-color, #000000);
+  transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
+  cursor: pointer;
+  text-align: center;
+}
+.outline-arrow:hover {
+  color: var(--accent-color, #f3f4f6); /* Matches hover:bg-accent */
+}
+.outline-arrow:disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}
+
+/* <Button variant="ghost" size="icon" onClick={() => setIsOpen(!isOpen)} className="relative z-50 ml-4">
+                        {isOpen ? <X size={24} /> : <Menu size={24} />}
+                    </Button> */
+/* Side panel button styles */
+.side-panel-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem; /* Matches size="icon" */
+  height: 2.5rem;
+  padding: 0px 0.75rem;
+  font-size: 1rem; /* Adjust icon size */
+  font-weight: 500;
+  border: none;
+  background-color: transparent;
+  color: var(--text-color, #000000);
+  border-radius: 0.375rem; /* Rounded square */
+  /* border-radius: 50%; Circular button */
+  transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
+  cursor: pointer;
+  text-align: center;
+}
+.side-panel-button:hover {
+  background-color: var(--accent-color, #f3f4f6); /* Matches hover:bg-accent */
+  color: var(--accent-foreground-color, #000000); /* Matches hover:text-accent-foreground */
+}
+.side-panel-button:disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -248,7 +248,7 @@ a {
 }
 
 /* White background button styles */
-.white-bg-button {
+.white-bg-link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -265,67 +265,11 @@ a {
   text-align: center;
   white-space: nowrap;
 }
-.white-bg-button:hover {
+.white-bg-link:hover {
   background-color: var(--accent-color, #f3f4f6); /* Matches hover:bg-accent */
   color: var(--accent-foreground-color, #000000); /* Matches hover:text-accent-foreground */
 }
 .white-bg-button:disabled {
-  pointer-events: none;
-  opacity: 0.5;
-}
-
-
-/* Outline arrow button styles */
-.outline-arrow {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1rem; /* Matches size="icon" */
-  height: 2rem;
-  padding: 0;
-  font-size: 1rem;
-  font-weight: 500;
-  background-color: transparent;
-  color: var(--text-color, #000000);
-  transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-  cursor: pointer;
-  text-align: center;
-}
-.outline-arrow:hover {
-  color: var(--accent-color, #f3f4f6); /* Matches hover:bg-accent */
-}
-.outline-arrow:disabled {
-  pointer-events: none;
-  opacity: 0.5;
-}
-
-/* <Button variant="ghost" size="icon" onClick={() => setIsOpen(!isOpen)} className="relative z-50 ml-4">
-                        {isOpen ? <X size={24} /> : <Menu size={24} />}
-                    </Button> */
-/* Side panel button styles */
-.side-panel-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 2.5rem; /* Matches size="icon" */
-  height: 2.5rem;
-  padding: 0px 0.75rem;
-  font-size: 1rem; /* Adjust icon size */
-  font-weight: 500;
-  border: none;
-  background-color: transparent;
-  color: var(--text-color, #000000);
-  border-radius: 0.375rem; /* Rounded square */
-  /* border-radius: 50%; Circular button */
-  transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-  cursor: pointer;
-  text-align: center;
-}
-.side-panel-button:hover {
-  background-color: var(--accent-color, #f3f4f6); /* Matches hover:bg-accent */
-  color: var(--accent-foreground-color, #000000); /* Matches hover:text-accent-foreground */
-}
-.side-panel-button:disabled {
   pointer-events: none;
   opacity: 0.5;
 }
@@ -341,7 +285,7 @@ a {
 }
 
 /* Social button styles */
-.social-button {
+.social-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -353,11 +297,11 @@ a {
   cursor: pointer;
   /* flex-shrink: 0; */
 }
-.social-button:hover {
+.social-icon:hover {
   background-color: var(--accent-color, #f3f4f6); /* Matches hover:bg-accent */
   /* transform: scale(1.05); Slight zoom effect on hover */
 }
-.social-button:disabled {
+.social-icon:disabled {
   pointer-events: none;
   opacity: 0.5;
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -329,3 +329,35 @@ a {
   pointer-events: none;
   opacity: 0.5;
 }
+
+/* Rating element styles */
+.rating {
+  display: inline-flex;
+  align-items: center;
+  font-size: 1.125rem; /* Matches text-lg */
+  color: var(--color-yellow, #fbbf24); /* Yellow color for stars */
+  font-weight: 500;
+  gap: 0.25rem; /* Space between the star and the rating number */
+}
+
+/* Social button styles */
+.social-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0px 10px;
+  width: max-content; /* Adjusts to the aspect ratio of the icon */
+  height: 3rem; /* Default height for consistency */
+  border-radius: 0.375rem; /* Rounded square */
+  transition: background-color 0.2s, transform 0.2s;
+  cursor: pointer;
+  /* flex-shrink: 0; */
+}
+.social-button:hover {
+  background-color: var(--accent-color, #f3f4f6); /* Matches hover:bg-accent */
+  /* transform: scale(1.05); Slight zoom effect on hover */
+}
+.social-button:disabled {
+  pointer-events: none;
+  opacity: 0.5;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -247,33 +247,6 @@ a {
   }
 }
 
-/* White background button styles */
-.white-bg-link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 100%;
-  padding: 0.5rem 1rem;
-  font-size: 0.875rem; /* Adjust for text-sm */
-  font-weight: 500;
-  border: 1px solid var(--input-border-color, #d1d5db); /* Matches outline variant */
-  background-color: var(--background-color, #ffffff);
-  color: var(--text-color, #000000);
-  border-radius: 0.375rem; /* Matches rounded-md */
-  transition: background-color 0.2s, color 0.2s, box-shadow 0.2s;
-  cursor: pointer;
-  text-align: center;
-  white-space: nowrap;
-}
-.white-bg-link:hover {
-  background-color: var(--accent-color, #f3f4f6); /* Matches hover:bg-accent */
-  color: var(--accent-foreground-color, #000000); /* Matches hover:text-accent-foreground */
-}
-.white-bg-button:disabled {
-  pointer-events: none;
-  opacity: 0.5;
-}
-
 /* Rating element styles */
 .rating {
   display: inline-flex;


### PR DESCRIPTION
## Global Component Styling
Here is an overview of the elements that I have modulated, with their .css names and how to use them:
- `white-bg-button`: this forms the basic oblong buttons such as the shop buttons in the product card and slidey
  - call this with the button text (usage inside a <link> as it was before)
- `outline-arrow`: this is the no-background arrow which turns lightly grey (basically white) when hovered, i.e. the ones used in the banner
  - call with the appropriate icon, i.e. arrowLeft or arrowRight, and size (e.g. for banner size=20)
- `side-panel-button`: this is used for the hamburger and close button for now, but when the shopping cart is implemented it can be used there too
  - call with the actual icon used, and the on-click navigation (e.g. setIsOpen(True))
- `rating`: this is simply the format for the rating, number+star format
  - call with the rating variable and star emoji/icon
- `social-button`: this is used for the interactive socila media icons, i.e. those used in the footer and in the navbar side menu
  - call *as a link* with the reference, and include the image inside