### PR TITLE
feature/NAG-44-Create-api-and-privacy-routes-for-main

### DIFF
--- a/src/app/api/instagram-webhook/route.js
+++ b/src/app/api/instagram-webhook/route.js
@@ -1,0 +1,24 @@
+export async function GET(req) {
+    const { searchParams } = new URL(req.url);
+
+    const mode = searchParams.get('hub.mode');
+    const token = searchParams.get('hub.verify_token');
+    const challenge = searchParams.get('hub.challenge');
+
+    const VERIFY_TOKEN = process.env.FB_VERIFY_TOKEN;
+
+    if (mode === 'subscribe' && token === VERIFY_TOKEN) {
+        return new Response(challenge, { status: 200 });
+    } else {
+        return new Response('Forbidden', { status: 403 });
+    }
+}
+  
+export async function POST(req) {
+    const body = await req.json();
+    console.log('Received Instagram webhook event:', body);
+
+    // You can process or store this data here
+
+    return new Response('Event Received', { status: 200 });
+}

--- a/src/app/privacy-policy/page.js
+++ b/src/app/privacy-policy/page.js
@@ -1,0 +1,28 @@
+export default function PrivacyPolicyPage() {
+    return (
+      <main className="max-w-2xl mx-auto px-4 py-12">
+        <h1 className="text-3xl font-bold mb-6">Privacy Policy</h1>
+        <p className="mb-4">
+          At Nutrinana, we are committed to protecting your privacy. This Privacy Policy explains how we collect, use, and safeguard your information when you visit our website.
+        </p>
+        <p className="mb-4">
+          We do not collect or store any personal data through this staging version of our website. No information is shared with third parties, and no cookies or tracking mechanisms are in place during this development phase.
+        </p>
+        <p className="mb-4">
+          When the site is fully launched, any data collection will be clearly outlined in an updated Privacy Policy that complies with all relevant data protection laws, including GDPR and CCPA.
+        </p>
+        <p className="mb-4">
+          By using this site, you acknowledge this privacy policy and agree to its terms. If you do not agree, please do not use the site.
+        </p>
+        <p>
+          If you have any questions about this policy or how we handle data, you can contact us at info@nutrinana.co.uk.
+        </p>
+  
+        <h2>Data Deletion Request</h2>
+          <p>
+          Nutrinana does not collect personal data through this application. If you believe any information has been collected and would like it removed, please contact us at 
+          <a href="mailto:info@nutrinana.co.uk">info@nutrinana.co.uk</a> and we will process your request promptly.
+          </p>
+      </main>
+    );
+  }

--- a/src/app/robots.js
+++ b/src/app/robots.js
@@ -1,0 +1,26 @@
+/**
+ * Dynamic robots.txt generator for Nutrinana.
+ * This follows the Robots Exclusion Standard and includes a sitemap.
+ * Blocks all crawlers in non-production environments.
+ * 
+ * @returns {Object} - The robots.txt configuration object.
+ */
+const isProduction = process.env.NODE_ENV === "production";
+
+export default function robots() {
+  return isProduction
+    ? {
+        rules: {
+          userAgent: '*',
+          allow: '/',
+          disallow: ['/privacy-policy/', '/api/'],
+        },
+        //sitemap: 'https://nutrinana.co.uk/sitemap.xml',
+      }
+    : {
+        rules: {
+          userAgent: '*',
+          disallow: '/',
+        },
+      };
+}


### PR DESCRIPTION
# Creat API and Privacy Routes for Main

## Key Changes
1. A dynamic `robots.txt` file to control search engine crawling. 
3. A new Instagram Webhook API route for handling Graph API events.
4. A publicly accessible Privacy Policy page required for Facebook App review.

## Testing Notes
- **`robots.txt`**:
  - Change your `NODE_ENV` to "production" without the quotes.
  - Run `npm run build` && `npm start`
  - Visit `http://localhost:3000/robots.txt` and confirm correct output.
    - _Production: Allows bots but disallows `/privacy-policy/` and `/api/`._

- **Instagram webhook**:
  - This will be confirmed once everything is merged as I need the callback url to be readily available online.

- **Privacy policy**:
  - Visit `/privacy-policy` and confirm something is there.
  
_Also I have sent out an invite for the new app on facebook developer. I have added all the relevant environment variables into Coolify too (including your `RESEND_API_KEY`). Note that the `INSTAGRAM_ACCESS_TOKEN` is a different value but same name. I also deleted a few unecessary variables._