### PR TITLE
Feature/nag 38 create error 404 page

### DIFF
--- a/src/app/error.js
+++ b/src/app/error.js
@@ -14,7 +14,7 @@ import Link from "next/link";
  * 
  * @returns {JSX.Element} The error page component.
  */
-export default function Error({ error, reset }) {
+export default function Error({ error }) {
     useEffect(() => {
         console.error("Global error caught by error.js:", error);
     }, [error]);

--- a/src/app/error.js
+++ b/src/app/error.js
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { Button } from "@/components/ui/button";
+import Link from "next/link";
 
 /**
  * Global error page component for handling unhandled exceptions.
@@ -25,8 +26,8 @@ export default function Error({ error, reset }) {
                 Oops! Looks like one of our granola clusters fell apart.<br />
                 Please try again or head back home.
             </p>
-            <Button variant="green" onClick={() => reset()}>
-                Try Again
+            <Button variant="green" asChild>
+                <Link href="/">Go Back Home</Link>
             </Button>
         </div>
     );

--- a/src/app/error.js
+++ b/src/app/error.js
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Button } from "@/components/ui/button";
+
+/**
+ * Global error page component for handling unhandled exceptions.
+ * Displayed when a rendering or data-fetching error occurs in the app.
+ *
+ * @param {Object} props - The component props.
+ * @param {Error} props.error - The error object thrown.
+ * @param {Function} props.reset - Callback to retry rendering the route.
+ * 
+ * @returns {JSX.Element} The error page component.
+ */
+export default function Error({ error, reset }) {
+    useEffect(() => {
+        console.error("Global error caught by error.js:", error);
+    }, [error]);
+
+    return (
+        <div className="min-h-screen flex flex-col items-center justify-center px-6 text-center">
+            <h1 className="text-4xl font-bold mb-4">Something went wrong 😵‍💫</h1>
+            <p className="text-gray-600 mb-6">
+                Oops! Looks like one of our granola clusters fell apart.<br />
+                Please try again or head back home.
+            </p>
+            <Button variant="green" onClick={() => reset()}>
+                Try Again
+            </Button>
+        </div>
+    );
+}

--- a/src/app/not-found.js
+++ b/src/app/not-found.js
@@ -10,7 +10,7 @@ export default function NotFound() {
     <div className="flex flex-col items-center justify-center min-h-screen px-6 text-center">
       <h1 className="text-4xl font-bold mb-4">404 — Page Not Found 🥜</h1>
       <p className="text-gray-600 mb-6">
-        Oops! We couldn’t find the page you were looking for.
+        Aw, nuts! We couldn’t find the page you were looking for.
       </p>
       <Button variant="green" asChild>
         <Link href="/">Return to Home</Link>

--- a/src/app/not-found.js
+++ b/src/app/not-found.js
@@ -1,0 +1,20 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Custom 404 Not Found page.
+ * This page is shown when a user navigates to a non-existent route.
+ */
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen px-6 text-center">
+      <h1 className="text-4xl font-bold mb-4">404 — Page Not Found 🥜</h1>
+      <p className="text-gray-600 mb-6">
+        Oops! We couldn’t find the page you were looking for.
+      </p>
+      <Button variant="green" asChild>
+        <Link href="/">Return to Home</Link>
+      </Button>
+    </div>
+  );
+}

--- a/src/app/test/page.js
+++ b/src/app/test/page.js
@@ -141,6 +141,8 @@ export default function TestPage() {
         <HeroSlider slides={slides} />
         <main className="p-10">
             <h1 className="text-3xl font-bold">Component Preview</h1>
+            <h2 className="text-2xl font-bold mb-4">Error Test</h2>
+            <p>Visit <a href="test/test-error" className="text-blue-600 underline">/test-error</a> to trigger the error page.</p>
             <section className="my-10">
               <h2 className="text-2xl font-semibold mb-4">Button Variants</h2>
               <div className="flex flex-wrap gap-4">

--- a/src/app/test/test-error/page.js
+++ b/src/app/test/test-error/page.js
@@ -1,0 +1,4 @@
+export default function TestErrorPage() {
+    // Simulate an error on render
+    throw new Error("Simulated error to test error.js");
+  }


### PR DESCRIPTION
# Custom Error Pages

This PR introduces two custom error handling pages to improve user experience and maintain consistent branding when errors occur:
  - `error.js`: Handles unexpected runtime errors such as rendering failures or data-fetching issues.
  - `not-found.js`: Displays a custom 404 page when a user navigates to a non-existent route.

## Key Changes

- Added `app/error.js` to handle global runtime errors.
- Added `app/not-found.js`.
- Added `test-error/page.js` to test the error page.

## Testing Notes

- Trigger the `/test-error` route to test runtime error handling via `error.js`. This can be doen by clicking on the link in the test page (http://localhost:3000/test). 
- Navigated to a non-existent route to confirm `not-found.js` rendering (e.g. click the "Reviews" tab).
- Verified layout and responsive behavior across screen sizes, mobile and desktop view.
- Questions: 
  - You came up with a quirky message the last time we spoke about this, if you remember please put it in the `not-found.js` page instead of what I have.
  - Do you think we should specifically design some artwork for this page? If so what?