### PR TITLE
bugfix: NAG-74 use decode function for review.title

### DIFF
--- a/src/components/RecentReviewCards.jsx
+++ b/src/components/RecentReviewCards.jsx
@@ -86,7 +86,7 @@ export default function RecentReviewCards() {
                             </div>
                             {/* Review title and content */}
                             <h3 className="font-display text-raisin mb-1 text-lg">
-                                {review.title}
+                                {decode(review.title)}
                             </h3>
                             <p className="mb-2 text-sm text-gray-700">
                                 {decode(review.content).length > 180 ? (

--- a/src/components/TopFiveReviews.jsx
+++ b/src/components/TopFiveReviews.jsx
@@ -73,7 +73,7 @@ export default function TopFiveReviews({ autoRotateMs = 7000 }) {
                             </header>
 
                             <h4 className="font-display text-raisin mb-1 text-base sm:text-lg">
-                                {review.title}
+                                {decode(review.title)}
                             </h4>
                             <p className="text-sm text-gray-700">
                                 {decode(review.content).length > 100


### PR DESCRIPTION
# Decode HTML entities in review titles

This PR resolves an issue where HTML entities (such as `&amp;`) were displayed in review titles on the `RecentReviewCards` component and by extension the `TopFiveReviews` component.

## Key Changes
- Applied `decode()` to review titles in `RecentReviewCards` and `TopFiveReviews`.

## Testing Notes
- Ensure review titles now display correctly without showing raw HTML entities.